### PR TITLE
feat: allow to have default value for the column name

### DIFF
--- a/lib/src/main/java/com/deblock/cucumber/datatable/annotations/Column.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/annotations/Column.java
@@ -15,7 +15,7 @@ public @interface Column {
     /**
      * the column name, you can specify multiple value to allow to use multiple column names
      */
-    String[] value();
+    String[] value() default {};
 
     String description() default "";
 

--- a/lib/src/main/java/com/deblock/cucumber/datatable/data/DatatableHeader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/data/DatatableHeader.java
@@ -1,5 +1,7 @@
 package com.deblock.cucumber.datatable.data;
 
+import com.deblock.cucumber.datatable.annotations.Column;
+
 import java.util.List;
 
 public record DatatableHeader(
@@ -8,6 +10,20 @@ public record DatatableHeader(
         boolean optional,
         String defaultValue,
         TypeMetadata typeMetadata) {
+
+    public DatatableHeader(
+            Column column,
+            String originalFieldName,
+            TypeMetadata typeMetadata
+    ) {
+        this(
+            buildNames(column.value(), originalFieldName),
+            column.description(),
+            !column.mandatory() || !column.defaultValue().isEmpty(),
+            column.defaultValue().isEmpty() ? null : column.defaultValue(),
+            typeMetadata
+        );
+    }
 
     public boolean match(String name) {
         return this.names.contains(name);
@@ -19,5 +35,16 @@ public record DatatableHeader(
 
     public String typeDescription() {
         return this.typeMetadata.typeDescription();
+    }
+
+    private static List<String> buildNames(String[] names, String fieldName) {
+        if (names != null && names.length > 0) {
+            return List.of(names);
+        }
+        return List.of(humanName(fieldName), fieldName);
+    }
+
+    private static String humanName(String name) {
+        return name.replaceAll("([a-z])([A-Z])", "$1 $2").trim().toLowerCase();
     }
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/BeanMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/BeanMapper.java
@@ -69,10 +69,8 @@ public class BeanMapper implements DatatableMapper {
                 .findFirst();
 
         final var header = new DatatableHeader(
-                List.of(column.value()),
-                column.description(),
-                !column.mandatory() || !column.defaultValue().isEmpty(),
-                column.defaultValue().isEmpty() ? null : column.defaultValue(),
+                column,
+                field.getName(),
                 typeMetadataFactory.build(setters.isEmpty() ? field.getGenericType() : setters.get().getGenericParameterTypes()[0])
         );
         if (setters.isPresent()) {

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/RecordMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/RecordMapper.java
@@ -73,11 +73,9 @@ public class RecordMapper implements DatatableMapper {
         final var column = recordComponent.getAnnotation(Column.class);
 
         return new DatatableHeader(
-                List.of(column.value()),
-                column.description(),
-                !column.mandatory() || !column.defaultValue().isEmpty(),
-                column.defaultValue().isEmpty() ? null : column.defaultValue(),
-                typeMetadataFactory.build(recordComponent.getGenericType())
+            column,
+            recordComponent.getName(),
+            typeMetadataFactory.build(recordComponent.getGenericType())
         );
     }
 

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/BeanMapperTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/BeanMapperTest.java
@@ -29,7 +29,8 @@ public class BeanMapperTest {
                 new DatatableHeader(List.of("intProp"), "a property with primitive int", true, "10", null),
                 new DatatableHeader(List.of("other bean", "my bean"), "", true, null, null),
                 new DatatableHeader(List.of("private list"), "", false, null, null),
-                new DatatableHeader(List.of("mandatory with default value"), "", true, "default", null)
+                new DatatableHeader(List.of("mandatory with default value"), "", true, "default", null),
+                new DatatableHeader(List.of("field with default name", "fieldWithDefaultName"), "", false, null, null)
         );
         assertThat(result)
                 .usingRecursiveComparison()
@@ -79,10 +80,12 @@ public class BeanMapperTest {
         final var result = (Bean) beanMapper.convert(Map.of(
                 "stringProp", "string",
                 "intProp", "101",
-                "private list", "10,11"
+                "private list", "10,11",
+                "field with default name", "test"
         ));
 
         assertThat(result.prop).isEqualTo("string");
+        assertThat(result.fieldWithDefaultName).isEqualTo("test");
         assertThat(result.intProp).isEqualTo(101);
         assertThat(result.getPrivateList()).isEqualTo(List.of("10", "11"));
     }
@@ -98,6 +101,7 @@ public class BeanMapperTest {
 
         assertThat(result.prop).isEqualTo("string");
         assertThat(result.intProp).isEqualTo(10);
+        assertThat(result.fieldWithDefaultName).isEqualTo(null);
         assertThat(result.getPrivateList()).isEqualTo(List.of("10", "11"));
     }
 

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/RecordMapperTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/RecordMapperTest.java
@@ -25,6 +25,7 @@ public class RecordMapperTest {
                 new DatatableHeader(List.of("intProp"), "a property with primitive int", true, "10", null),
                 new DatatableHeader(List.of("other bean", "my bean"), "", true, null, null),
                 new DatatableHeader(List.of("list"), "", false, null, null),
+                new DatatableHeader(List.of("field with default name", "fieldWithDefaultName"), "", false, null, null),
                 new DatatableHeader(List.of("mandatory with default value"), "", true, "default", null)
         );
         assertThat(result)
@@ -40,10 +41,12 @@ public class RecordMapperTest {
         final var result = (Record) beanMapper.convert(Map.of(
                 "stringProp", "string",
                 "intProp", "101",
-                "list", "10,11"
+                "list", "10,11",
+                "field with default name", "test"
         ));
 
         assertThat(result.prop()).isEqualTo("string");
+        assertThat(result.fieldWithDefaultName()).isEqualTo("test");
         assertThat(result.intProp()).isEqualTo(101);
         assertThat(result.list()).isEqualTo(List.of("10", "11"));
         assertThat(result.otherBean()).isNull();
@@ -63,6 +66,7 @@ public class RecordMapperTest {
         assertThat(result.intProp()).isEqualTo(10);
         assertThat(result.list()).isEqualTo(List.of("10", "11"));
         assertThat(result.otherBean()).isNull();
+        assertThat(result.fieldWithDefaultName()).isNull();
         assertThat(result.nonAnnotatedColumn()).isNull();
     }
 

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Bean.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Bean.java
@@ -22,6 +22,9 @@ public class Bean {
     @Column(value = {"mandatory with default value"}, defaultValue = "default")
     public String mandatoryWithDefaultValue;
 
+    @Column
+    public String fieldWithDefaultName;
+
     private String nonAnnotatedColumn;
 
     public static class OtherBean {

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Record.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Record.java
@@ -16,6 +16,8 @@ public record Record(
     OtherBean otherBean,
     @Column(value = "list")
     List<String> list,
+    @Column()
+    String fieldWithDefaultName,
     @Column(value = {"mandatory with default value"}, defaultValue = "default")
     String mandatoryWithDefaultValue
 ) {


### PR DESCRIPTION
Add default value when no column name are specified on `@Column` annotation
The default have two value: 
   - the field name (`mySuperField`)  
   - the human readable field name (`my super field`) 

fix #16