### PR TITLE
fix: mapping to single object

### DIFF
--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/BeanDatatableTypeDefinition.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/BeanDatatableTypeDefinition.java
@@ -8,6 +8,7 @@ import io.cucumber.datatable.TableTransformer;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class BeanDatatableTypeDefinition implements DataTableTypeDefinition  {
@@ -26,26 +27,38 @@ public class BeanDatatableTypeDefinition implements DataTableTypeDefinition  {
         return new DataTableType(
                 this.glueClass,
                 (TableTransformer<Object>) table -> {
-                    Map<String, String> map;
-                    try {
-                        map = new HashMap<>();
+                    final Map<String, String> map = new HashMap<>();
+                    final long firstRowNumberOfHeader = numberOfCommonHeader(table.row(0));
+                    final long firstColumnNumberOfHeader = numberOfCommonHeader(table.column(0));
+                    final boolean isTwoColumnTable = table.row(0).size() == 2;
+
+                    if (
+                            firstRowNumberOfHeader > firstColumnNumberOfHeader
+                            || (firstRowNumberOfHeader == firstColumnNumberOfHeader && !isTwoColumnTable)
+                    ) {
                         // table using only one row
                         for (var i = 0; i < table.width(); ++i) {
                             map.put(table.row(0).get(i), table.row(1).get(i));
                         }
-                        map.values().removeAll(Collections.singleton(null));
-                        this.validator.validate(map.keySet());
-                    } catch (Exception e) {
-                        map = new HashMap<>();
+                    } else {
                         // table using 2 columns mode
                         for (var i = 0; i < table.height(); ++i) {
                             map.put(table.column(0).get(i), table.column(1).get(i));
                         }
-                        map.values().removeAll(Collections.singleton(null));
-                        this.validator.validate(map.keySet());
                     }
+                    map.values().removeAll(Collections.singleton(null));
+                    this.validator.validate(map.keySet());
                     return this.datatableMapper.convert(map);
                 });
+    }
+
+    private long numberOfCommonHeader(List<String> firstRow) {
+        return this.datatableMapper.headers().stream()
+                .filter(header ->
+                        header.names().stream()
+                                .anyMatch(firstRow::contains)
+                )
+                .count();
     }
 
     @Override
@@ -57,4 +70,6 @@ public class BeanDatatableTypeDefinition implements DataTableTypeDefinition  {
     public String getLocation() {
         return null;
     }
+
+
 }


### PR DESCRIPTION
In the previous commit, when attempting to map a DataTable to a simple object, a confusing error message was displayed in case of header mismatch. For instance, consider the following scenario:

**Step Definition:**
```java
@Given("a step with only one object")
public void step(PrimitiveBean bean) {
    System.out.println("read: " + bean);
}
```

**DataTable Class:**
```java
@DataTableWithHeader
public class PrimitiveBean {
    @Column(value = "string")
    public String string;

    @Column(value = "integer")
    public Integer integer;
}
```

**Scenario:**
```gherkin
Given a step with only one object
  | string with error | integer |
  | s                 | 10      |
```

Previously, this resulted in the following error message:
```
The following headers "s", "string with error" are not defined for this dataTable. Available headers are "string", "integer"
```

However, after this fix, the error message now correctly reflects the issue:
```
The following headers "integer", "string with error" are not defined for this dataTable. Available headers are "string", "integer"
```

Additionally, you can utilize the following alternative format for the DataTable, which will also be handled gracefully:
```gherkin
Given a step with only one object
  | string  | s   |
  | integer | 10  |
```

This merge request aims to enhance clarity and usability in error reporting when encountering DataTable header mismatches.
