### PR TITLE
feat: set \@Column and \@DataTableHeader as facultative

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,34 @@ Using this bean:
 
 ``` java 
 @DataTableWithHeader // this annotation is used to register this class as a Datatable
+                     // This is facultative but may improve test startup performance
 class Bean {
     @Column("column 1") // this annotation register this var as a column of the datatable
     public String column1;
 
     @Column(value = "column2", mandatory = false)
     public String column2;
+    
+    public String column3;
+    
+    @Ignore // this annotation ensure ensure this will not be registered as a column of the datatable
+    public String column4;
 }
 
 // compatible with records
-@DataTableWithHeader // this annotation is used to register this class as a Datatable
 record Bean(
     @Column("column 1") // this annotation register this var as a column of the datatable
     String column1,
     @Column(value = "column2", mandatory = false)
-    String column2
+    String column2,
+    String column4,
+    @Ignore  // this annotation ensure ensure this will not be registered as a column of the datatable
+    String column2  
 ) { }
+
+// ignore class/record completely
+@Ignore
+record Bean(String column1)
 
 ```
 

--- a/lib/src/main/java/com/deblock/cucumber/datatable/annotations/CustomDatatableFieldMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/annotations/CustomDatatableFieldMapper.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This function allow to define a customer mapper.
+ * This function allows to define a customer mapper.
  * The annotated function should:
  *   - be static
  *   - have one string parameter

--- a/lib/src/main/java/com/deblock/cucumber/datatable/annotations/Ignore.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/annotations/Ignore.java
@@ -1,0 +1,13 @@
+package com.deblock.cucumber.datatable.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation signals a class/field that should not be mapped
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT, ElementType.PARAMETER})
+public @interface Ignore {}

--- a/lib/src/main/java/com/deblock/cucumber/datatable/data/DatatableHeader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/data/DatatableHeader.java
@@ -12,6 +12,16 @@ public record DatatableHeader(
         String defaultValue,
         TypeMetadata typeMetadata) {
 
+	public DatatableHeader(ColumnNameBuilder columnNameBuilder, TypeMetadata typeMetadata) {
+		this(
+			columnNameBuilder.build(), 
+			null, 
+			false, 
+			null, 
+			typeMetadata
+		);
+	}
+	
     public DatatableHeader(
             Column column,
             ColumnNameBuilder columnNameBuilder,

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/GenericMapperFactory.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/GenericMapperFactory.java
@@ -14,6 +14,7 @@ import com.deblock.cucumber.datatable.mapper.typemetadata.exceptions.NoConverter
 import java.lang.reflect.Type;
 
 public class GenericMapperFactory implements MapperFactory {
+	
     private final TypeMetadataFactory typeMetadataFactory;
 
     public GenericMapperFactory(TypeMetadataFactory typeMetadataFactory) {
@@ -37,7 +38,24 @@ public class GenericMapperFactory implements MapperFactory {
             );
         } catch (NoConverterFound ex) {
             if (type instanceof Class<?> clazz && clazz.isAnnotationPresent(DataTableWithHeader.class)) {
-                return new ColumnAnnotatedObjectDatatableMapper(column, this.getBaseObjectDatatableMapper(clazz, nameBuilder));
+                return new ColumnAnnotatedObjectDatatableMapper(column.mandatory(), this.getBaseObjectDatatableMapper(clazz, nameBuilder));
+            }
+        }
+        return new NotMappedDatatableMapper();
+    }
+    
+    @Override
+    public DatatableMapper build(ColumnNameBuilder nameBuilder, Type type) {
+        try {
+            typeMetadataFactory.build(type);
+            return new SimpleColumnDatatableMapper(
+                    nameBuilder,
+                    type,
+                    typeMetadataFactory
+            );
+        } catch (NoConverterFound ex) {
+            if (type instanceof Class<?> clazz && clazz.isAnnotationPresent(DataTableWithHeader.class)) {
+                return new ColumnAnnotatedObjectDatatableMapper(false, this.getBaseObjectDatatableMapper(clazz, nameBuilder));
             }
         }
         return new NotMappedDatatableMapper();

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/MapperFactory.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/MapperFactory.java
@@ -10,4 +10,7 @@ public interface MapperFactory {
     DatatableMapper build(Class<?> recordClass);
 
     DatatableMapper build(Column column, ColumnNameBuilder name, Type type);
+
+    DatatableMapper build(ColumnNameBuilder name, Type type);
+
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/BeanDatatableMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/BeanDatatableMapper.java
@@ -1,6 +1,7 @@
 package com.deblock.cucumber.datatable.mapper.datatable;
 
 import com.deblock.cucumber.datatable.annotations.Column;
+import com.deblock.cucumber.datatable.annotations.Ignore;
 import com.deblock.cucumber.datatable.data.DatatableHeader;
 import com.deblock.cucumber.datatable.mapper.DatatableMapper;
 import com.deblock.cucumber.datatable.mapper.MalformedBeanException;
@@ -23,11 +24,8 @@ import java.util.function.BiConsumer;
 import static java.util.Locale.ENGLISH;
 
 public class BeanDatatableMapper extends BaseObjectDatatableMapper<BeanDatatableMapper.FieldData> {
-    private final Constructor<?> constructor;
-
-    public BeanDatatableMapper(Class<?> clazz, MapperFactory mapperFactory) {
-        this(clazz, mapperFactory, null);
-    }
+    
+	private final Constructor<?> constructor;
 
     public BeanDatatableMapper(Class<?> clazz, MapperFactory mapperFactory, ColumnNameBuilder parentNameBuilder) {
         super(buildFieldsData(clazz, mapperFactory, parentNameBuilder));
@@ -52,13 +50,12 @@ public class BeanDatatableMapper extends BaseObjectDatatableMapper<BeanDatatable
 
     private static List<FieldData> buildFieldsData(Class<?> clazz, MapperFactory mapperFactory, ColumnNameBuilder columnNameBuilder) {
         return Arrays.stream(clazz.getDeclaredFields())
-                .filter(field -> field.isAnnotationPresent(Column.class))
+        		.filter(field -> !field.isAnnotationPresent(Ignore.class))
                 .map(field -> buildFieldData(clazz, field, mapperFactory, columnNameBuilder))
                 .toList();
     }
-
+    
     private static FieldData buildFieldData(Class<?> clazz, Field field, MapperFactory mapperFactory, ColumnNameBuilder columnNameBuilder) {
-        final var column = field.getAnnotation(Column.class);
         final var setterName = "set" + capitalize(field.getName());
         final var setter = Arrays.stream(clazz.getMethods())
                 .filter(method -> method.getName().equals(setterName))
@@ -66,14 +63,21 @@ public class BeanDatatableMapper extends BaseObjectDatatableMapper<BeanDatatable
                 .filter(method -> Modifier.isPublic(method.getModifiers()))
                 .findFirst();
 
-        final var datatableMapper = mapperFactory.build(
-            column,
-            new WithParentNameBuilder(
-                    columnNameBuilder,
-                    new ColumnNameBuilderChain(new FromAnnotationColumnNameBuilder(column), new FromFieldNameBuilder(field))
-            ),
-            setter.map(it -> it.getGenericParameterTypes()[0]).orElseGet(field::getGenericType)
-        );
+		final DatatableMapper datatableMapper;
+		if (field.isAnnotationPresent(Column.class)) {
+			final var column = field.getAnnotation(Column.class);
+			datatableMapper = mapperFactory
+					.build(column,
+							new WithParentNameBuilder(columnNameBuilder,
+									new ColumnNameBuilderChain(new FromAnnotationColumnNameBuilder(column),
+											new FromFieldNameBuilder(field))),
+							setter.map(it -> it.getGenericParameterTypes()[0]).orElseGet(field::getGenericType));
+		} else {
+			datatableMapper = mapperFactory
+					.build(new WithParentNameBuilder(columnNameBuilder,
+							new ColumnNameBuilderChain(new FromFieldNameBuilder(field))),
+							setter.map(it -> it.getGenericParameterTypes()[0]).orElseGet(field::getGenericType));
+		}
 
         if (setter.isPresent()) {
             return new FieldData(datatableMapper, (bean, object) -> {

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/ColumnAnnotatedObjectDatatableMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/ColumnAnnotatedObjectDatatableMapper.java
@@ -1,6 +1,5 @@
 package com.deblock.cucumber.datatable.mapper.datatable;
 
-import com.deblock.cucumber.datatable.annotations.Column;
 import com.deblock.cucumber.datatable.data.DatatableHeader;
 import com.deblock.cucumber.datatable.mapper.DatatableMapper;
 import com.deblock.cucumber.datatable.validator.DataTableDoesNotMatch;
@@ -11,19 +10,19 @@ import java.util.Map;
 
 public class ColumnAnnotatedObjectDatatableMapper implements DatatableMapper {
 
+	private final boolean mandatory;
     private final DatatableMapper objectMapper;
-    private final Column annotation;
     private final DataTableValidator validator;
 
-    public ColumnAnnotatedObjectDatatableMapper(Column annotation, DatatableMapper objectMapper) {
+    public ColumnAnnotatedObjectDatatableMapper(boolean mandatory, DatatableMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.annotation = annotation;
+        this.mandatory = mandatory;
         this.validator = new DataTableValidator(objectMapper.headers(), true);
     }
 
     @Override
     public List<DatatableHeader> headers() {
-        if (this.annotation.mandatory()) {
+        if (this.mandatory) {
             return this.objectMapper.headers();
         }
         return this.objectMapper.headers()

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/SimpleColumnDatatableMapper.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/datatable/SimpleColumnDatatableMapper.java
@@ -21,9 +21,14 @@ public class SimpleColumnDatatableMapper implements DatatableMapper {
     private final TypeMetadata typeMetadata;
     private final DatatableHeader header;
 
-    public SimpleColumnDatatableMapper(Column column, ColumnNameBuilder nameBuilder, Type genericType, TypeMetadataFactory typeMetadataFactory) {
+    public SimpleColumnDatatableMapper(ColumnNameBuilder nameBuilder, Type genericType, TypeMetadataFactory typeMetadataFactory) {
         this.typeMetadata = typeMetadataFactory.build(genericType);
-        this.header = new DatatableHeader(column, nameBuilder, typeMetadata);
+        this.header = new DatatableHeader(nameBuilder, typeMetadata);
+    }
+    
+    public SimpleColumnDatatableMapper(Column column, ColumnNameBuilder nameBuilder, Type genericType, TypeMetadataFactory typeMetadataFactory) {
+    	this.typeMetadata = typeMetadataFactory.build(genericType);
+    	this.header = new DatatableHeader(column, nameBuilder, typeMetadata);
     }
 
     @Override

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/BeanMapperTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/BeanMapperTest.java
@@ -25,8 +25,10 @@ public class BeanMapperTest {
 
     @Test
     public void shouldReadMetadataFromColumnAnnotatedColumns() {
-        final var beanMapper = new BeanDatatableMapper(Bean.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()));
-
+		final var beanMapper = new BeanDatatableMapper(Bean.class,
+				new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()), 
+				()-> List.of("fieldName"));
+		
         final var result = beanMapper.headers();
 
         List<DatatableHeader> expectedHeaders = List.of(
@@ -35,8 +37,10 @@ public class BeanMapperTest {
                 new DatatableHeader(List.of("other bean", "my bean"), "", true, null, null),
                 new DatatableHeader(List.of("private list"), "", false, null, null),
                 new DatatableHeader(List.of("mandatory with default value"), "", true, "default", null),
-                new DatatableHeader(List.of("field with default name", "fieldWithDefaultName"), "", false, null, null)
+                new DatatableHeader(List.of("field with default name", "fieldWithDefaultName"), "", false, null, null),
+                new DatatableHeader(List.of("non annotated column", "nonAnnotatedColumn"), null, false, null, null)
         );
+        
         assertThat(result)
                 .usingRecursiveComparison()
                 .ignoringFields("typeMetadata")
@@ -45,8 +49,10 @@ public class BeanMapperTest {
 
     @Test
     public void shouldReadMetadataFromColumnAnnotatedColumnsOnNestedObjects() {
-        final var beanMapper = new BeanDatatableMapper(BeanWithNestedObjects.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()));
-
+		final var beanMapper = new BeanDatatableMapper(BeanWithNestedObjects.class,
+				new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()), 
+				()-> List.of("fieldName"));
+		
         final var result = beanMapper.headers();
 
         List<DatatableHeader> expectedHeaders = List.of(
@@ -66,8 +72,10 @@ public class BeanMapperTest {
 
     @Test
     public void shouldReplaceParentName() {
-        final var beanMapper = new BeanDatatableMapper(BeanWithNestedRecordNameMapping.class, new GenericMapperFactory(new RecordDatatableMapperTest.MockMetadataFactory()));
-
+		final var beanMapper = new BeanDatatableMapper(BeanWithNestedRecordNameMapping.class,
+				new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()), 
+				()-> List.of("fieldName"));
+		
         final var result = beanMapper.headers();
 
         List<DatatableHeader> expectedHeaders = List.of(
@@ -87,7 +95,9 @@ public class BeanMapperTest {
     public void shouldReturnErrorIfPrivateFieldHasNoSetter() {
         final var malformedBeanException = Assertions.assertThrows(
                 MalformedBeanException.class,
-                () -> new BeanDatatableMapper(MalformedBeanPrivateColumnWithoutSetter.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()))
+                () -> new BeanDatatableMapper(MalformedBeanPrivateColumnWithoutSetter.class, 
+                		new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()),
+                		()-> List.of("fieldName"))
         );
 
         assertThat(malformedBeanException.getMessage())
@@ -98,7 +108,9 @@ public class BeanMapperTest {
     public void shouldReturnErrorIfPrivateFieldHasPrivateSetter() {
         final var malformedBeanException = Assertions.assertThrows(
                 MalformedBeanException.class,
-                () -> new BeanDatatableMapper(MalformedBeanPrivateColumnWithPrivateSetter.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()))
+                () -> new BeanDatatableMapper(MalformedBeanPrivateColumnWithPrivateSetter.class, 
+                		new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()),
+                		()-> List.of("fieldName"))
         );
 
         assertThat(malformedBeanException.getMessage())
@@ -109,7 +121,9 @@ public class BeanMapperTest {
     public void shouldReturnErrorIfThereIsNoPublicConstructor() {
         final var malformedBeanException = Assertions.assertThrows(
                 MalformedBeanException.class,
-                () -> new BeanDatatableMapper(MalformedBeanWithPrivateConstructor.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()))
+                () -> new BeanDatatableMapper(MalformedBeanWithPrivateConstructor.class, 
+                		new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()),
+                		()-> List.of("fieldName"))
         );
 
         assertThat(malformedBeanException.getMessage())
@@ -118,7 +132,9 @@ public class BeanMapperTest {
 
     @Test
     public void shouldMapDataToBean() {
-        final var beanMapper = new BeanDatatableMapper(Bean.class,new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()));
+		final var beanMapper = new BeanDatatableMapper(Bean.class,
+				new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()), 
+				()-> List.of("fieldName"));
 
         final var result = (Bean) beanMapper.convert(Map.of(
                 "stringProp", "string",
@@ -135,7 +151,9 @@ public class BeanMapperTest {
 
     @Test
     public void shouldSetDefaultValueIfColumnIsNotSet() {
-        final var beanMapper = new BeanDatatableMapper(Bean.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()));
+        final var beanMapper = new BeanDatatableMapper(Bean.class, 
+        		new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()),
+        		()-> List.of("fieldName"));
 
         final var result = (Bean) beanMapper.convert(Map.of(
                 "stringProp", "string",
@@ -150,7 +168,9 @@ public class BeanMapperTest {
 
     @Test
     public void shouldMapDataToBeanWithNestedObjectWithAllRequiredObjectFilled() {
-        final var beanMapper = new BeanDatatableMapper(BeanWithNestedObjects.class, new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()));
+        final var beanMapper = new BeanDatatableMapper(BeanWithNestedObjects.class, 
+        		new GenericMapperFactory(new BeanMapperTest.MockMetadataFactory()),
+        		()-> List.of("fieldName"));
 
         final var result = (BeanWithNestedObjects) beanMapper.convert(Map.of(
                 "column", "value",
@@ -218,4 +238,5 @@ public class BeanMapperTest {
             };
         }
     }
+    
 }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Bean.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/Bean.java
@@ -2,6 +2,7 @@ package com.deblock.cucumber.datatable.mapper.beans;
 
 import com.deblock.cucumber.datatable.annotations.Column;
 import com.deblock.cucumber.datatable.annotations.DataTableWithHeader;
+import com.deblock.cucumber.datatable.annotations.Ignore;
 
 import java.util.List;
 
@@ -25,7 +26,10 @@ public class Bean {
     @Column
     public String fieldWithDefaultName;
 
-    private String nonAnnotatedColumn;
+    public String nonAnnotatedColumn;
+
+    @Ignore
+    public String ignoredColumn;
 
     public static class OtherBean {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
-rootProject.name = 'cucumber-datatable-to-bean-mapping-root'
+rootProject.name = 'cucumber-datatable-to-bean-mapping'
 
 include 'lib'
 include 'demo'
 include 'demo-java8'
-


### PR DESCRIPTION
Following a discussion we had sometimes ago, here is a proposition to simplify the use of the library:

From now on, a bean/class is registered if it hasn't the \@Ignore annotation and if one of the following  condition is true :
  * class is a record
  * class is annotated with \@DataTableHeader annotation
  * class has public non final field
  * class has public setters

\@Colum becomes facultative, any public non final field or field with setter will be mapped unless it has the \@Ignore annotation (default values are: name of the field, null description, mandatory false (to not break existing project using the library), null default value)

First time contributing to the project, hope it is not too much changes