### PR TITLE
feat: allow to have a custom DateTimeService implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ The following types can be auto mapped:
 
   `now` will return the same date at each step of the test.
 
+> :information_source: You can customize the way to resolve `now`. 
+> 
+> You can implement the interface `com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService` and implement your custom now function.
+> 
+> To use you custom class, you should set the property `cucumber.datatable.mapper.date-time-service-class` with your class reference.
+> 
+> You should create a file `META-INF/services/com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService` and put your class reference inside.
+
 ### Custom type support
 
 If you want to use a custom type on datatable, you can write custom mapper. It can be useful when you want to convert id
@@ -305,6 +313,9 @@ cucumber.datatable.mapper.name-builder-class=com.deblock.cucumber.datatable.mapp
 # com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver -- Only fields with @Column annotation will be mapped
 # com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.ImplicitFieldResolver -- All fields of your class will be mapped
 cucumber.datatable.mapper.field-resolver-class=com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver
+# This property allow to specify how to get the now date time. You can implement your own class if you want customize it
+# com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService -- The now date is static and be the same during all the test execution
+cucumber.datatable.mapper.date-time-service-class=com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService
 ```
 
 ## Usage on a fat/uber jar

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/DefaultOptions.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/DefaultOptions.java
@@ -4,6 +4,8 @@ import com.deblock.cucumber.datatable.mapper.datatable.FieldResolver;
 import com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder;
 import com.deblock.cucumber.datatable.mapper.name.HumanReadableColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService;
 
 public class DefaultOptions implements FullOptions {
     @Override
@@ -14,5 +16,10 @@ public class DefaultOptions implements FullOptions {
     @Override
     public Class<? extends FieldResolver> getFieldResolverClass() {
         return DeclarativeFieldResolver.class;
+    }
+
+    @Override
+    public Class<? extends DateTimeService> getDateTimeServiceClass() {
+        return StaticDateTimeService.class;
     }
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/MergedOptions.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/MergedOptions.java
@@ -3,6 +3,7 @@ package com.deblock.cucumber.datatable.backend.options;
 import com.deblock.cucumber.datatable.mapper.Options;
 import com.deblock.cucumber.datatable.mapper.datatable.FieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,11 @@ public class MergedOptions implements FullOptions {
     @Override
     public Class<? extends FieldResolver> getFieldResolverClass() {
         return getOption(Options::getFieldResolverClass);
+    }
+
+    @Override
+    public Class<? extends DateTimeService> getDateTimeServiceClass() {
+        return getOption(Options::getDateTimeServiceClass);
     }
 
     private <T> T getOption(Function<FullOptions, T> supplier) {

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/PropertiesConstants.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/PropertiesConstants.java
@@ -14,4 +14,9 @@ public final class PropertiesConstants {
      * com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.ImplicitFieldResolver -- Register all fields public or with a setter. @Ignore annotation can be used to ignore a field
      */
     public static final String FIELD_RESOLVER_CLASS_PROPERTY_NAME = "cucumber.datatable.mapper.field-resolver-class";
+    /**
+     * This property allow to specify how to get the now date time.
+     * com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService -- The now date is static and be the same during all the test execution
+     */
+    public static final String DATE_TIME_SERVICE_CLASS_PROPERTY_NAME = "cucumber.datatable.mapper.date-time-service-class";
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/PropertiesOptions.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/options/PropertiesOptions.java
@@ -2,10 +2,12 @@ package com.deblock.cucumber.datatable.backend.options;
 
 import com.deblock.cucumber.datatable.mapper.datatable.FieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
 import io.cucumber.core.exception.CucumberException;
 
 import java.util.Map;
 
+import static com.deblock.cucumber.datatable.backend.options.PropertiesConstants.DATE_TIME_SERVICE_CLASS_PROPERTY_NAME;
 import static com.deblock.cucumber.datatable.backend.options.PropertiesConstants.FIELD_RESOLVER_CLASS_PROPERTY_NAME;
 import static com.deblock.cucumber.datatable.backend.options.PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME;
 
@@ -26,6 +28,11 @@ public class PropertiesOptions implements FullOptions {
         return getClassParameter(FIELD_RESOLVER_CLASS_PROPERTY_NAME, FieldResolver.class);
     }
 
+    @Override
+    public Class<? extends DateTimeService> getDateTimeServiceClass() {
+        return getClassParameter(DATE_TIME_SERVICE_CLASS_PROPERTY_NAME, DateTimeService.class);
+    }
+
     private <T> Class<T> getClassParameter(String property, Class<T> loaderClazz) {
         final String className = properties.get(property);
         if (className == null) {
@@ -34,7 +41,7 @@ public class PropertiesOptions implements FullOptions {
         try {
             Class<?> clazz = Class.forName(className);
             if (!loaderClazz.isAssignableFrom(clazz)) {
-                throw new CucumberException("Name builder class '%s' was not a subclass of '%s'.".formatted(clazz, loaderClazz));
+                throw new CucumberException("The class '%s' was not a subclass of '%s'.".formatted(clazz, loaderClazz));
             }
             return (Class<T>) clazz;
         } catch (ClassNotFoundException e) {

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/Options.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/Options.java
@@ -2,8 +2,10 @@ package com.deblock.cucumber.datatable.mapper;
 
 import com.deblock.cucumber.datatable.mapper.datatable.FieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
 
 public interface Options {
     Class<? extends ColumnNameBuilder> getNameBuilderClass();
     Class<? extends FieldResolver> getFieldResolverClass();
+    Class<? extends DateTimeService> getDateTimeServiceClass();
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/DateTimeService.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/DateTimeService.java
@@ -2,7 +2,7 @@ package com.deblock.cucumber.datatable.mapper.typemetadata.date;
 
 import java.time.OffsetDateTime;
 
-public interface GetDateService {
+public interface DateTimeService {
 
     OffsetDateTime now();
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/StaticDateTimeService.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/StaticDateTimeService.java
@@ -2,8 +2,8 @@ package com.deblock.cucumber.datatable.mapper.typemetadata.date;
 
 import java.time.OffsetDateTime;
 
-public class StaticGetTimeService implements GetDateService {
-    private final OffsetDateTime NOW = OffsetDateTime.now();
+public class StaticDateTimeService implements DateTimeService {
+    private static final OffsetDateTime NOW = OffsetDateTime.now();
 
     @Override
     public OffsetDateTime now() {

--- a/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/TemporalTypeMetadataFactory.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/mapper/typemetadata/date/TemporalTypeMetadataFactory.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class TemporalTypeMetadataFactory implements TypeMetadataFactory {
     private final Map<Class<?>, TypeMetadata> temporalTypeMetadataByTypes;
 
-    public TemporalTypeMetadataFactory(GetDateService getDateService) {
+    public TemporalTypeMetadataFactory(DateTimeService getDateService) {
         this.temporalTypeMetadataByTypes = Map.of(
                 OffsetDateTime.class, new DateTimeTypeMetadata(getDateService::now, OffsetDateTime::parse),
                 LocalDateTime.class, new DateTimeTypeMetadata(() -> getDateService.now().toLocalDateTime(), LocalDateTime::parse),

--- a/lib/src/main/java/com/deblock/cucumber/datatable/runtime/AbstractServiceLoader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/runtime/AbstractServiceLoader.java
@@ -1,0 +1,45 @@
+package com.deblock.cucumber.datatable.runtime;
+
+import io.cucumber.core.exception.CucumberException;
+
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+public abstract class AbstractServiceLoader<T> {
+
+    private final Supplier<ClassLoader> classLoaderSupplier;
+    private final Class<T> serviceInterface;
+    private final Class<? extends T> expectedClass;
+
+    protected AbstractServiceLoader(
+            Class<T> serviceInterface,
+            Class<? extends T> expectedClass,
+            Supplier<ClassLoader> classLoaderSupplier
+    ) {
+        this.serviceInterface = serviceInterface;
+        this.expectedClass = expectedClass;
+        this.classLoaderSupplier = classLoaderSupplier;
+    }
+
+    public T loadService() {
+        ServiceLoader<T> loader = ServiceLoader.load(serviceInterface, classLoaderSupplier.get());
+
+        for (T serviceClass : loader) {
+            if (expectedClass.equals(serviceClass.getClass())) {
+                return serviceClass;
+            }
+        }
+
+        throw new CucumberException(
+                """
+                Could not find class %s.
+                Cucumber uses SPI to discover %s implementations.
+                Has the class been registered with SPI and is it available on the classpath?
+                You should register the class %s on a file names META-INF/services/%s
+                """.formatted(
+                    expectedClass.getName(), serviceInterface.getSimpleName(),
+                    expectedClass.getName(), serviceInterface.getName()
+                )
+        );
+    }
+}

--- a/lib/src/main/java/com/deblock/cucumber/datatable/runtime/ColumnNameBuilderServiceLoader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/runtime/ColumnNameBuilderServiceLoader.java
@@ -2,36 +2,11 @@ package com.deblock.cucumber.datatable.runtime;
 
 import com.deblock.cucumber.datatable.mapper.Options;
 import com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder;
-import io.cucumber.core.exception.CucumberException;
 
-import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
-public class ColumnNameBuilderServiceLoader {
-    private final Options options;
-    private final Supplier<ClassLoader> classLoaderSupplier;
-
+public class ColumnNameBuilderServiceLoader extends AbstractServiceLoader<ColumnNameBuilder> {
     public ColumnNameBuilderServiceLoader(Options options, Supplier<ClassLoader> classLoaderSupplier) {
-        this.options = options;
-        this.classLoaderSupplier = classLoaderSupplier;
-    }
-
-    public ColumnNameBuilder loadColumnNameBuilder() {
-        ServiceLoader<ColumnNameBuilder> loader = ServiceLoader.load(ColumnNameBuilder.class, classLoaderSupplier.get());
-        Class<? extends ColumnNameBuilder> expectedClass = this.options.getNameBuilderClass();
-
-        for (ColumnNameBuilder columnNameBuilder : loader) {
-            if (expectedClass.equals(columnNameBuilder.getClass())) {
-                return columnNameBuilder;
-            }
-        }
-
-        throw new CucumberException(
-                """
-                Could not find name builder %s.
-                Cucumber uses SPI to discover name builder implementations.
-                Has the class been registered with SPI and is it available on the classpath?
-                """.formatted(expectedClass.getName())
-                );
+        super(ColumnNameBuilder.class, options.getNameBuilderClass(), classLoaderSupplier);
     }
 }

--- a/lib/src/main/java/com/deblock/cucumber/datatable/runtime/DateTimeServiceLoader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/runtime/DateTimeServiceLoader.java
@@ -1,0 +1,12 @@
+package com.deblock.cucumber.datatable.runtime;
+
+import com.deblock.cucumber.datatable.mapper.Options;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
+
+import java.util.function.Supplier;
+
+public class DateTimeServiceLoader extends AbstractServiceLoader<DateTimeService> {
+    public DateTimeServiceLoader(Options options, Supplier<ClassLoader> classLoaderSupplier) {
+        super(DateTimeService.class, options.getDateTimeServiceClass(), classLoaderSupplier);
+    }
+}

--- a/lib/src/main/java/com/deblock/cucumber/datatable/runtime/FieldResolverServiceLoader.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/runtime/FieldResolverServiceLoader.java
@@ -2,39 +2,21 @@ package com.deblock.cucumber.datatable.runtime;
 
 import com.deblock.cucumber.datatable.mapper.Options;
 import com.deblock.cucumber.datatable.mapper.datatable.FieldResolver;
-import io.cucumber.core.exception.CucumberException;
 
-import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
-public class FieldResolverServiceLoader {
-    private final Options options;
-    private final Supplier<ClassLoader> classLoaderSupplier;
+public class FieldResolverServiceLoader extends AbstractServiceLoader<FieldResolver> {
     private final ColumnNameBuilderServiceLoader columnNameBuilderServiceLoader;
 
     public FieldResolverServiceLoader(Options options, Supplier<ClassLoader> classLoaderSupplier, ColumnNameBuilderServiceLoader columnNameBuilderServiceLoader) {
-        this.options = options;
-        this.classLoaderSupplier = classLoaderSupplier;
+        super(FieldResolver.class, options.getFieldResolverClass(), classLoaderSupplier);
         this.columnNameBuilderServiceLoader = columnNameBuilderServiceLoader;
     }
 
-    public FieldResolver loadFieldResolverBuilder() {
-        ServiceLoader<FieldResolver> loader = ServiceLoader.load(FieldResolver.class, classLoaderSupplier.get());
-        Class<? extends FieldResolver> expectedClass = this.options.getFieldResolverClass();
-
-        for (FieldResolver fieldResolver : loader) {
-            if (expectedClass.equals(fieldResolver.getClass())) {
-                fieldResolver.configure(this.columnNameBuilderServiceLoader.loadColumnNameBuilder());
-                return fieldResolver;
-            }
-        }
-
-        throw new CucumberException(
-                """
-                Could not find field resolver %s.
-                Cucumber uses SPI to discover name builder implementations.
-                Has the class been registered with SPI and is it available on the classpath?
-                """.formatted(expectedClass.getName())
-        );
+    @Override
+    public FieldResolver loadService() {
+        FieldResolver fieldResolver = super.loadService();
+        fieldResolver.configure(this.columnNameBuilderServiceLoader.loadService());
+        return fieldResolver;
     }
 }

--- a/lib/src/main/resources/META-INF/services/com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService
+++ b/lib/src/main/resources/META-INF/services/com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService
@@ -1,0 +1,1 @@
+com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService

--- a/lib/src/test/java/com/deblock/cucumber/datatable/backend/options/MergedOptionsTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/backend/options/MergedOptionsTest.java
@@ -1,40 +1,121 @@
 package com.deblock.cucumber.datatable.backend.options;
 
+import com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver;
+import com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.ImplicitFieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.HumanReadableColumnNameBuilder;
 import com.deblock.cucumber.datatable.mapper.name.UseFieldNameColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.OffsetDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MergedOptionsTest {
+class MergedOptionsTest {
 
-    @Test
-    public void getNameBuilderClassShouldReturnNullWhenNoOneHasTheProperty() {
-        final var option1 = Mockito.mock(FullOptions.class);
-        final var option2 = Mockito.mock(FullOptions.class);
-        final var mergedOptions = new MergedOptions(
-                option1, option2
-        );
+    @Nested
+    class GetNameBuilderClassMethod {
+        @Test
+        void shouldReturnNullWhenNoOneHasTheProperty() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2
+            );
 
-        final var result = mergedOptions.getNameBuilderClass();
+            final var result = mergedOptions.getNameBuilderClass();
 
-        assertThat(result).isNull();
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnTheFirstValueNonNull() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var option3 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2, option3
+            );
+            Mockito.when(option2.getNameBuilderClass()).thenReturn((Class) HumanReadableColumnNameBuilder.class);
+            Mockito.when(option3.getNameBuilderClass()).thenReturn((Class) UseFieldNameColumnNameBuilder.class);
+
+            final var result = mergedOptions.getNameBuilderClass();
+
+            assertThat(result).isEqualTo(HumanReadableColumnNameBuilder.class);
+        }
     }
 
-    @Test
-    public void getNameBuilderClassShouldReturnTheFirstValueNonNull() {
-        final var option1 = Mockito.mock(FullOptions.class);
-        final var option2 = Mockito.mock(FullOptions.class);
-        final var option3 = Mockito.mock(FullOptions.class);
-        final var mergedOptions = new MergedOptions(
-                option1, option2, option3
-        );
-        Mockito.when(option2.getNameBuilderClass()).thenReturn((Class) HumanReadableColumnNameBuilder.class);
-        Mockito.when(option3.getNameBuilderClass()).thenReturn((Class) UseFieldNameColumnNameBuilder.class);
+    @Nested
+    class GetFieldResolverClassMethod {
+        @Test
+        void shouldReturnNullWhenNoOneHasTheProperty() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2
+            );
 
-        final var result = mergedOptions.getNameBuilderClass();
+            final var result = mergedOptions.getFieldResolverClass();
 
-        assertThat(result).isEqualTo(HumanReadableColumnNameBuilder.class);
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnTheFirstValueNonNull() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var option3 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2, option3
+            );
+            Mockito.when(option2.getFieldResolverClass()).thenReturn((Class) ImplicitFieldResolver.class);
+            Mockito.when(option3.getFieldResolverClass()).thenReturn((Class) DeclarativeFieldResolver.class);
+
+            final var result = mergedOptions.getFieldResolverClass();
+
+            assertThat(result).isEqualTo(ImplicitFieldResolver.class);
+        }
+    }
+
+    @Nested
+    class GetDateTimeServiceClassMethod {
+        @Test
+        void shouldReturnNullWhenNoOneHasTheProperty() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2
+            );
+
+            final var result = mergedOptions.getDateTimeServiceClass();
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnTheFirstValueNonNull() {
+            final var option1 = Mockito.mock(FullOptions.class);
+            final var option2 = Mockito.mock(FullOptions.class);
+            final var option3 = Mockito.mock(FullOptions.class);
+            final var mergedOptions = new MergedOptions(
+                    option1, option2, option3
+            );
+            Mockito.when(option2.getDateTimeServiceClass()).thenReturn((Class) StaticDateTimeService.class);
+            Mockito.when(option3.getDateTimeServiceClass()).thenReturn((Class) TestDateTimeService.class);
+
+            final var result = mergedOptions.getDateTimeServiceClass();
+
+            assertThat(result).isEqualTo(StaticDateTimeService.class);
+        }
+    }
+
+    class TestDateTimeService implements DateTimeService {
+        @Override
+        public OffsetDateTime now() {
+            return null;
+        }
     }
 }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/backend/options/PropertiesOptionsTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/backend/options/PropertiesOptionsTest.java
@@ -1,7 +1,10 @@
 package com.deblock.cucumber.datatable.backend.options;
 
+import com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver;
 import com.deblock.cucumber.datatable.mapper.name.HumanReadableColumnNameBuilder;
+import com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService;
 import io.cucumber.core.exception.CucumberException;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -9,47 +12,140 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PropertiesOptionsTest {
+class PropertiesOptionsTest {
 
-    @Test
-    public void getNameBuilderClassShouldThrowExceptionIfClassDoesNotExists() {
-        PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
-                PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.test.TestUnknown"
-        ));
+    @Nested
+    class GetNameBuilderClassMethod {
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExists() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.test.TestUnknown"
+            ));
 
-        final var exception = assertThrows(CucumberException.class, () -> propertiesOptions.getNameBuilderClass());
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getNameBuilderClass);
 
-        assertThat(exception).hasMessage("The class 'com.test.TestUnknown' of configuration 'cucumber.datatable.mapper.name-builder-class' is not found.");
+            assertThat(exception).hasMessage("The class 'com.test.TestUnknown' of configuration 'cucumber.datatable.mapper.name-builder-class' is not found.");
+        }
+
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExtendsNameBuilder() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest"
+            ));
+
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getNameBuilderClass);
+
+            assertThat(exception).hasMessage("The class 'class com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest' was not a subclass of 'interface com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder'.");
+        }
+
+        @Test
+        void shouldReturnTheClassIfItIsOk() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.mapper.name.HumanReadableColumnNameBuilder"
+            ));
+
+            final var result = propertiesOptions.getNameBuilderClass();
+
+            assertThat(result).isEqualTo(HumanReadableColumnNameBuilder.class);
+        }
+
+        @Test
+        void returnNullIfPropertyIsNotSet() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of());
+
+            final var result = propertiesOptions.getNameBuilderClass();
+
+            assertThat(result).isNull();
+        }
     }
 
-    @Test
-    public void getNameBuilderClassShouldThrowExceptionIfClassDoesNotExtendsNameBuilder() {
-        PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
-                PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest"
-        ));
+    @Nested
+    class GetFieldResolverClassMethod {
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExists() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.FIELD_RESOLVER_CLASS_PROPERTY_NAME, "com.test.TestUnknown"
+            ));
 
-        final var exception = assertThrows(CucumberException.class, () -> propertiesOptions.getNameBuilderClass());
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getFieldResolverClass);
 
-        assertThat(exception).hasMessage("Name builder class 'class com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest' was not a subclass of 'interface com.deblock.cucumber.datatable.mapper.name.ColumnNameBuilder'.");
+            assertThat(exception).hasMessage("The class 'com.test.TestUnknown' of configuration 'cucumber.datatable.mapper.field-resolver-class' is not found.");
+        }
+
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExtendsNameBuilder() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.FIELD_RESOLVER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest"
+            ));
+
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getFieldResolverClass);
+
+            assertThat(exception).hasMessage("The class 'class com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest' was not a subclass of 'interface com.deblock.cucumber.datatable.mapper.datatable.FieldResolver'.");
+        }
+
+        @Test
+        void shouldReturnTheClassIfItIsOk() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.FIELD_RESOLVER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.mapper.datatable.fieldresolvers.DeclarativeFieldResolver"
+            ));
+
+            final var result = propertiesOptions.getFieldResolverClass();
+
+            assertThat(result).isEqualTo(DeclarativeFieldResolver.class);
+        }
+
+        @Test
+        void returnNullIfPropertyIsNotSet() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of());
+
+            final var result = propertiesOptions.getFieldResolverClass();
+
+            assertThat(result).isNull();
+        }
     }
 
-    @Test
-    public void getNameBuilderClassShouldReturnTheClassIfItIsOk() {
-        PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
-                PropertiesConstants.NAME_BUILDER_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.mapper.name.HumanReadableColumnNameBuilder"
-        ));
+    @Nested
+    class GetDateTimeServiceClassMethod {
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExists() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.DATE_TIME_SERVICE_CLASS_PROPERTY_NAME, "com.test.TestUnknown"
+            ));
 
-        final var result = propertiesOptions.getNameBuilderClass();
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getDateTimeServiceClass);
 
-        assertThat(result).isEqualTo(HumanReadableColumnNameBuilder.class);
-    }
+            assertThat(exception).hasMessage("The class 'com.test.TestUnknown' of configuration 'cucumber.datatable.mapper.date-time-service-class' is not found.");
+        }
 
-    @Test
-    public void getNameBuilderReturnNullIfPropertyIsNotSet() {
-        PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of());
+        @Test
+        void shouldThrowExceptionIfClassDoesNotExtendsNameBuilder() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.DATE_TIME_SERVICE_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest"
+            ));
 
-        final var result = propertiesOptions.getNameBuilderClass();
+            final var exception = assertThrows(CucumberException.class, propertiesOptions::getDateTimeServiceClass);
 
-        assertThat(result).isNull();
+            assertThat(exception).hasMessage("The class 'class com.deblock.cucumber.datatable.backend.options.PropertiesOptionsTest' was not a subclass of 'interface com.deblock.cucumber.datatable.mapper.typemetadata.date.DateTimeService'.");
+        }
+
+        @Test
+        void shouldReturnTheClassIfItIsOk() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of(
+                    PropertiesConstants.DATE_TIME_SERVICE_CLASS_PROPERTY_NAME, "com.deblock.cucumber.datatable.mapper.typemetadata.date.StaticDateTimeService"
+            ));
+
+            final var result = propertiesOptions.getDateTimeServiceClass();
+
+            assertThat(result).isEqualTo(StaticDateTimeService.class);
+        }
+
+        @Test
+        void returnNullIfPropertyIsNotSet() {
+            PropertiesOptions propertiesOptions = new PropertiesOptions(Map.of());
+
+            final var result = propertiesOptions.getDateTimeServiceClass();
+
+            assertThat(result).isNull();
+        }
     }
 }


### PR DESCRIPTION
### Description

Introducing a customization of `DateTimeService` to enhance the flexibility of `now + x days` resolution.

### Purpose

Having a custom `DateTimeService` is beneficial for synchronizing the current date and time (`now`) with other libraries or components. This is particularly useful when generating JSON using templating, as it ensures consistency in the `now` value between your template and the datatable.

### Key Benefits

- **Customization**: Allows for a tailored `now` resolution to meet specific requirements.
- **Synchronization**: Ensures that the `now` value is consistent across different parts of the application, such as templates and datatables.
- **Flexibility**: Supports scenarios where alignment with other libraries or systems is necessary.

### Example Use Case

When generating JSON using a templating engine, you can ensure that the `now` value is identical in both the template and the datatable, improving consistency and reliability.
