### PR TITLE
feat: a support of dependency injection for CustomDatatableFieldMapper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,22 +111,13 @@ The following types can be auto mapped:
 
 ### Custom type support
 
-If you want to use a custom type on datatable, you can write custom mapper. It can be useful when you want to convert id
-to object.
+If you want to use a custom type on datatable, you can write custom mapper. 
+It can be useful when you want to convert id to object.
 
 For example, If you have an object `Customer`:
 
 ```java
-
-@DataTableWithHeader
-record Customer(
-        @Column("code")
-        String code,
-        @Column("first name")
-        String firstName,
-        @Column("last name")
-        String lastName
-) {
+record Customer(String code, String firstName, String lastName) {
 }
 ```
 
@@ -155,10 +146,9 @@ You need to write a function to map a string to a Customer.
 The function should be provided on your steps package.
 
 ```java
-
 @CustomDatatableFieldMapper(sample = "cucumberCode", typeDescription = "Customer")
-public static Customer customerMapper(String customerCode) {
-    return TestContext.getCustomer(customerCode);
+public Customer customerMapper(String customerCode) {
+    // Get the customer on your test context (using static context or injected with spring or picocontainer
 }
 ```
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -11,6 +11,7 @@ java {
 dependencies {
     testImplementation project(':lib')
     testImplementation 'io.cucumber:cucumber-java:7.8.1'
+    testImplementation 'io.cucumber:cucumber-picocontainer:7.8.1'
 }
 
 configurations {

--- a/demo/src/test/java/com/deblock/cucumber/ApplicationContext.java
+++ b/demo/src/test/java/com/deblock/cucumber/ApplicationContext.java
@@ -1,4 +1,7 @@
 package com.deblock.cucumber;
 
 public class ApplicationContext {
+    public String contextStringValue() {
+        return "contextStringValue";
+    }
 }

--- a/demo/src/test/java/com/deblock/cucumber/ApplicationContext.java
+++ b/demo/src/test/java/com/deblock/cucumber/ApplicationContext.java
@@ -1,0 +1,4 @@
+package com.deblock.cucumber;
+
+public class ApplicationContext {
+}

--- a/demo/src/test/java/com/deblock/cucumber/TestStep.java
+++ b/demo/src/test/java/com/deblock/cucumber/TestStep.java
@@ -1,6 +1,7 @@
 package com.deblock.cucumber;
 
 import com.deblock.cucumber.beans.CustomDTO;
+import com.deblock.cucumber.beans.OtherCustomDTO;
 import com.deblock.cucumber.beans.PrimitiveBean;
 import com.deblock.cucumber.beans.RecordBean;
 import com.deblock.cucumber.datatable.annotations.CustomDatatableFieldMapper;
@@ -21,6 +22,11 @@ public class TestStep {
             throw new IllegalArgumentException("error");
         }
         return new CustomDTO(value);
+    }
+
+    @CustomDatatableFieldMapper(sample = "valueString", typeDescription = "OtherCustomDTO")
+    public OtherCustomDTO otherCustomDTOMapper(String value) {
+        return new OtherCustomDTO(value, applicationContext.contextStringValue());
     }
 
     @Given("a step with only one object")

--- a/demo/src/test/java/com/deblock/cucumber/TestStep.java
+++ b/demo/src/test/java/com/deblock/cucumber/TestStep.java
@@ -9,6 +9,11 @@ import io.cucumber.java.en.Given;
 import java.util.List;
 
 public class TestStep {
+    private final ApplicationContext applicationContext;
+
+    public TestStep(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
 
     @CustomDatatableFieldMapper(sample = "valueString", typeDescription = "CustomDTO")
     public static CustomDTO customDTOMapper(String value) {

--- a/demo/src/test/java/com/deblock/cucumber/beans/OtherCustomDTO.java
+++ b/demo/src/test/java/com/deblock/cucumber/beans/OtherCustomDTO.java
@@ -1,0 +1,4 @@
+package com.deblock.cucumber.beans;
+
+public record OtherCustomDTO(String value, String contextValue) {
+}

--- a/demo/src/test/java/com/deblock/cucumber/beans/RecordBean.java
+++ b/demo/src/test/java/com/deblock/cucumber/beans/RecordBean.java
@@ -16,6 +16,8 @@ public record RecordBean(
     @Column(value = "enumValue", defaultValue = "VALUE2")
     EnumValue enumValue,
     @Column(value = "customDTO", mandatory = false)
-    CustomDTO customDTO
+    CustomDTO customDTO,
+    @Column(mandatory = false)
+    OtherCustomDTO otherCustomDTO
 ) {
 }

--- a/demo/src/test/resources/features/test.feature
+++ b/demo/src/test/resources/features/test.feature
@@ -6,9 +6,9 @@ Feature: Mapping
       | string | integer | integers      |
       | s      | 1       | 1, 3, 4, 5, 6 |
     And a step with a list of record
-      | string | integer | integers | customDTO |
-      | s      | 10      |          | false     |
-      | a      | 11      | 3, 1039  | test      |
+      | string | integer | integers | customDTO | other custom dto |
+      | s      | 10      |          | false     | test1            |
+      | a      | 11      | 3, 1039  | test      | test2            |
 
 
   Scenario: Failed due to typo on column

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/DatatableToBeanMappingBackend.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/DatatableToBeanMappingBackend.java
@@ -18,6 +18,7 @@ import com.deblock.cucumber.datatable.runtime.FieldResolverServiceLoader;
 import com.deblock.cucumber.datatable.validator.DataTableValidator;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
@@ -33,17 +34,19 @@ public class DatatableToBeanMappingBackend implements Backend {
     private final ClasspathScanner classFinder;
     private final FieldResolverServiceLoader fieldResolveServiceLoader;
     private final DateTimeServiceLoader dateTimeServiceLoader;
+    private final Lookup lookup;
 
-    public DatatableToBeanMappingBackend(Supplier<ClassLoader> classLoaderSupplier, FullOptions options) {
+    public DatatableToBeanMappingBackend(Supplier<ClassLoader> classLoaderSupplier, FullOptions options, Lookup lookup) {
         this.classFinder = new ClasspathScanner(classLoaderSupplier);
         final var columnNameBuilderServiceLoader = new ColumnNameBuilderServiceLoader(options, classLoaderSupplier);
         this.fieldResolveServiceLoader = new FieldResolverServiceLoader(options, classLoaderSupplier, columnNameBuilderServiceLoader);
         this.dateTimeServiceLoader = new DateTimeServiceLoader(options, classLoaderSupplier);
+        this.lookup = lookup;
     }
 
     @Override
     public void loadGlue(Glue glue, List<URI> gluePaths) {
-        final var customTypeMetadataFactory = new CustomTypeMetadataFactory(this.classFinder, gluePaths);
+        final var customTypeMetadataFactory = new CustomTypeMetadataFactory(this.classFinder, gluePaths, lookup);
         final var typeMetadataFactory = new CompositeTypeMetadataFactory(
             customTypeMetadataFactory,
             new PrimitiveTypeMetadataFactoryImpl(),

--- a/lib/src/main/java/com/deblock/cucumber/datatable/backend/DatatableToBeanMappingBackendProviderService.java
+++ b/lib/src/main/java/com/deblock/cucumber/datatable/backend/DatatableToBeanMappingBackendProviderService.java
@@ -20,6 +20,6 @@ public class DatatableToBeanMappingBackendProviderService implements BackendProv
                 new PropertiesOptions(CucumberProperties.fromPropertiesFile()),
                 new DefaultOptions()
         );
-        return new DatatableToBeanMappingBackend(classLoader, options);
+        return new DatatableToBeanMappingBackend(classLoader, options, lookup);
     }
 }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/custom/CustomBean.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/custom/CustomBean.java
@@ -9,7 +9,6 @@ public record CustomBean(String value) {
         return new CustomBean(value);
     }
 
-    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapFromNonString(Integer value) {
         return null;
     }
@@ -19,12 +18,10 @@ public record CustomBean(String value) {
         return new CustomBean(value);
     }
 
-    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapperWithoutParameter() {
         return null;
     }
 
-    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapperWithTwoParametersParameter(String value1, String value2) {
         return null;
     }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/custom/CustomBean.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/beans/custom/CustomBean.java
@@ -9,18 +9,22 @@ public record CustomBean(String value) {
         return new CustomBean(value);
     }
 
+    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapFromNonString(Integer value) {
         return null;
     }
 
+    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public CustomBean nonStaticMapperForTest(String value) {
-        return null;
+        return new CustomBean(value);
     }
 
+    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapperWithoutParameter() {
         return null;
     }
 
+    @CustomDatatableFieldMapper(sample = "aString", typeDescription = "CustomBean")
     public static CustomBean mapperWithTwoParametersParameter(String value1, String value2) {
         return null;
     }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataFactoryTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataFactoryTest.java
@@ -3,41 +3,47 @@ package com.deblock.cucumber.datatable.mapper.typemetadata.custom;
 
 import com.deblock.cucumber.datatable.mapper.beans.Bean;
 import com.deblock.cucumber.datatable.mapper.beans.custom.CustomBean;
+import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.resource.ClasspathScanner;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.net.URI;
 import java.util.List;
 
-public class CustomTypeMetadataFactoryTest {
+class CustomTypeMetadataFactoryTest {
+    Lookup lookup = Mockito.mock(Lookup.class);
 
     @Test
-    public void shouldAllowToRegisterCustomType() {
+    void shouldAllowToRegisterCustomType() {
         final var factory = new CustomTypeMetadataFactory(
                 new ClasspathScanner(
                         () -> this.getClass().getClassLoader()
                 ),
                 List.of(
                         URI.create("classpath:/com/deblock/cucumber/datatable/mapper/beans/custom")
-                )
+                ),
+                lookup
         );
 
         final var getTypeMetadata = factory.build(CustomBean.class);
 
-        Assertions.assertThat(getTypeMetadata).isNotNull();
-        Assertions.assertThat(getTypeMetadata).isInstanceOf(CustomJavaBeanTypeMetadata.class);
+        Assertions.assertThat(getTypeMetadata)
+                .isNotNull()
+                .isInstanceOf(CustomJavaBeanTypeMetadata.class);
     }
 
     @Test
-    public void shouldReturnNullIfTypeIsNotRegistered() {
+    void shouldReturnNullIfTypeIsNotRegistered() {
         final var factory = new CustomTypeMetadataFactory(
                 new ClasspathScanner(
                         () -> this.getClass().getClassLoader()
                 ),
                 List.of(
                         URI.create("classpath:/com/deblock/cucumber/datatable/mapper/beans/custom")
-                )
+                ),
+                lookup
         );
 
         final var getTypeMetadata = factory.build(Bean.class);

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataTest.java
@@ -4,18 +4,21 @@ import com.deblock.cucumber.datatable.annotations.CustomDatatableFieldMapper;
 import com.deblock.cucumber.datatable.data.TypeMetadata;
 import com.deblock.cucumber.datatable.mapper.beans.custom.CustomBean;
 import com.deblock.cucumber.datatable.mapper.beans.custom.CustomBean2;
+import io.cucumber.core.backend.Lookup;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-public class CustomTypeMetadataTest {
+class CustomTypeMetadataTest {
+    Lookup lookup = Mockito.mock(Lookup.class);
 
     @Test
-    public void shouldReturnAnnotationTypeDescriptionAsDescription() throws NoSuchMethodException {
+    void shouldReturnAnnotationTypeDescriptionAsDescription() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapFromString", String.class);
-        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class));
+        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class), lookup);
 
         final var result = typeMetadata.typeDescription();
 
@@ -23,9 +26,9 @@ public class CustomTypeMetadataTest {
     }
 
     @Test
-    public void shouldReturnAnnotationSampleAsSample() throws NoSuchMethodException {
+    void shouldReturnAnnotationSampleAsSample() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapFromString", String.class);
-        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class));
+        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class), lookup);
 
         final var result = typeMetadata.sample();
 
@@ -33,9 +36,9 @@ public class CustomTypeMetadataTest {
     }
 
     @Test
-    public void shouldUseTheMethodToMapString() throws NoSuchMethodException {
+    void shouldUseTheMethodToMapString() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapFromString", String.class);
-        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class));
+        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class), lookup);
 
         final var result = typeMetadata.convert("aValue");
 
@@ -44,9 +47,21 @@ public class CustomTypeMetadataTest {
     }
 
     @Test
-    public void shouldThrowConversionExceptionIfMapperFail() throws NoSuchMethodException {
+    void shouldUseNonStaticMethod() throws NoSuchMethodException {
+        Mockito.when(lookup.getInstance(CustomBean.class)).thenReturn(new CustomBean(""));
+        final var method = CustomBean.class.getMethod("nonStaticMapperForTest", String.class);
+        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class), lookup);
+
+        final var result = typeMetadata.convert("aValue");
+
+        assertThat(result).isInstanceOf(CustomBean.class);
+        assertThat(((CustomBean)result).value()).isEqualTo("aValue");
+    }
+
+    @Test
+    void shouldThrowConversionExceptionIfMapperFail() throws NoSuchMethodException {
         final var method = CustomBean2.class.getMethod("mapperThrowingException", String.class);
-        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class));
+        final var typeMetadata = new CustomJavaBeanTypeMetadata(method, method.getAnnotation(CustomDatatableFieldMapper.class), lookup);
 
         final var exception = Assertions.assertThrows(TypeMetadata.ConversionError.class, () -> typeMetadata.convert("aValue"));
 
@@ -55,43 +70,34 @@ public class CustomTypeMetadataTest {
     }
 
     @Test
-    public void shouldFailIfAnnotationIsNull() throws NoSuchMethodException {
+    void shouldFailIfAnnotationIsNull() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapFromString", String.class);
-        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null));
+        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null, lookup));
 
         assertThat(exception.getMessage()).isEqualTo("The annotation should not be null");
     }
 
-
     @Test
-    public void shouldFailIfMethodIsNotStatic() throws NoSuchMethodException {
-        final var method = CustomBean.class.getMethod("nonStaticMapperForTest", String.class);
-        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null));
-
-        assertThat(exception.getMessage()).isEqualTo("The method CustomBean.nonStaticMapperForTest should be static to be used with annotation CustomDatatableFieldMapper");
-    }
-
-    @Test
-    public void shouldFailIfMethodHasNoParameter() throws NoSuchMethodException {
+    void shouldFailIfMethodHasNoParameter() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapperWithoutParameter");
-        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null));
+        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null, lookup));
 
         assertThat(exception.getMessage()).isEqualTo("The method CustomBean.mapperWithoutParameter should have one String parameter to be used with annotation CustomDatatableFieldMapper");
 
     }
 
     @Test
-    public void shouldFailIfMethodHasMoreThanOneParameter() throws NoSuchMethodException {
+    void shouldFailIfMethodHasMoreThanOneParameter() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapperWithTwoParametersParameter", String.class, String.class);
-        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null));
+        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null, lookup));
 
         assertThat(exception.getMessage()).isEqualTo("The method CustomBean.mapperWithTwoParametersParameter should have one String parameter to be used with annotation CustomDatatableFieldMapper");
     }
 
     @Test
-    public void shouldFailIfMethodHasANonStringParameter() throws NoSuchMethodException {
+    void shouldFailIfMethodHasANonStringParameter() throws NoSuchMethodException {
         final var method = CustomBean.class.getMethod("mapFromNonString", Integer.class);
-        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null));
+        final var exception = Assertions.assertThrows(IllegalArgumentException.class, () -> new CustomJavaBeanTypeMetadata(method, null, lookup));
 
         assertThat(exception.getMessage()).isEqualTo("The method CustomBean.mapFromNonString should have one String parameter to be used with annotation CustomDatatableFieldMapper");
     }

--- a/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataTest.java
+++ b/lib/src/test/java/com/deblock/cucumber/datatable/mapper/typemetadata/custom/CustomTypeMetadataTest.java
@@ -65,7 +65,7 @@ class CustomTypeMetadataTest {
 
         final var exception = Assertions.assertThrows(TypeMetadata.ConversionError.class, () -> typeMetadata.convert("aValue"));
 
-        assertThat(exception.getMessage()).isEqualTo("error aValue is not supported");
+        assertThat(exception.getMessage()).isEqualTo("method CustomBean2.mapperThrowingException has throw the error: error aValue is not supported");
         assertThat(exception.getCause()).isNotNull();
     }
 


### PR DESCRIPTION
### Description

This PR enables dependency injection in methods annotated with `@CustomDatatableFieldMapper`.

### Purpose

Previously, methods annotated with `@CustomDatatableFieldMapper` had to be static, limiting their ability to use instance properties and access context-specific information. With this update, these methods can now be non-static, allowing for greater flexibility and integration with dependency injection frameworks like PicoContainer or Spring.

### Key Benefits

- **Dependency Injection Support**: Methods annotated with `@CustomDatatableFieldMapper` can now leverage dependency injection, making it easier to manage dependencies and access context classes.
- **Non-Static Methods**: Mapper methods can now be instance methods, allowing them to utilize instance properties and other non-static resources.
- **Enhanced Flexibility**: Improved compatibility with dependency injection frameworks such as PicoContainer and Spring, facilitating more dynamic and context-aware field mapping.

### Example Use Case

When using Spring or PicoContainer, you can now inject beans or other dependencies directly into your custom datatable field mapper methods, allowing them to access necessary context or services.


closes #15 